### PR TITLE
Add rake tasks for blacksmith

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet_blacksmith/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 


### PR DESCRIPTION
I forgot to include the rake tasks for puppet blacksmith so the puppet
forge release failed to run.